### PR TITLE
Strip the prefix from the Dim enum on printing

### DIFF
--- a/rspirv/mr/operand.rs
+++ b/rspirv/mr/operand.rs
@@ -78,7 +78,7 @@ impl fmt::Display for Operand {
             Operand::MemoryModel(ref v) => write!(f, "{:?}", v),
             Operand::ExecutionMode(ref v) => write!(f, "{:?}", v),
             Operand::StorageClass(ref v) => write!(f, "{:?}", v),
-            Operand::Dim(ref v) => write!(f, "{:?}", v),
+            Operand::Dim(ref v) => write!(f, "{}", &format!("{:?}", v)[3..]),
             Operand::SamplerAddressingMode(ref v) => write!(f, "{:?}", v),
             Operand::SamplerFilterMode(ref v) => write!(f, "{:?}", v),
             Operand::ImageFormat(ref v) => write!(f, "{:?}", v),


### PR DESCRIPTION
Tools like spirv-as fail on the invalid enum in the generated assembly.

I just changed the Display implementation of Operand because the change had the smallest footprint, but maybe a better fix would be manually implementing Debug for the Dim enum ?